### PR TITLE
Fix profile links

### DIFF
--- a/app/components/EditUserProfile.jsx
+++ b/app/components/EditUserProfile.jsx
@@ -57,6 +57,12 @@ class EditUserProfile extends Component {
   }
   handleSubmit() {
     const input = this.getInputData();
+
+    // Adds the scheme part of the URL in case it's missing.
+    if (!input.site.startsWith('http://') && !input.site.startsWith('https://')) {
+      input.site = 'http://'.concat(input.site);
+    }
+
     const toBeAdded = { uid: this.props.id, type: this.props.type };
     const dataToPass = { data: JSON.stringify(Object.assign(input, toBeAdded)) };
     this.props.handleSubmit(dataToPass);

--- a/app/components/UserCreation/UserCreationForm.jsx
+++ b/app/components/UserCreation/UserCreationForm.jsx
@@ -7,6 +7,14 @@ import StatusMessage from '../StatusMessage';
 function isValidEmail(string) {
   return string.includes('@');
 }
+
+function validateSite(addr) {
+  if (!addr.startsWith('http://') && !addr.startsWith('https://')) {
+    return 'http://'.concat(addr);
+  }
+  return addr;
+}
+
 // Form for createing user accounts.
 // Takes as props an onSubmit function and the wanted user type, either coach or startup
 export default class UserCreationForm extends React.Component {
@@ -39,6 +47,7 @@ export default class UserCreationForm extends React.Component {
     }
   }
 
+
   // validate the form fields based on form name prop
   // return "" if valid or an error string if invalid
   validate(name) {
@@ -66,6 +75,11 @@ export default class UserCreationForm extends React.Component {
   }
 
   handleSubmit() {
+    // Handles links so that theý always start with http:// or https://.
+    const site = this.props.type === 'coach' ? 'linkedin' : 'website';
+    this.setState({
+      [site]: validateSite(this.state[site]),
+    });
     // check that all fields are valid
     if (Object.entries(this.state).every(arr => this.validate(arr[0]) === '')) {
       this.props.onSubmit(this.state);

--- a/app/components/UserProfile.jsx
+++ b/app/components/UserProfile.jsx
@@ -7,7 +7,7 @@ import ProfileInfoHeader from './ProfileInfoHeader';
 // React Component for a user's profile page.
 export default class UserProfile extends React.Component {
   render() {
-    const siteName = this.props.type === 'Coach' ? 'LinkedIn' : 'Website';
+    const siteName = this.props.type === 'coach' ? 'LinkedIn' : 'Website';
     return (
       <div className="profileContainer container">
         <link rel="stylesheet" type="text/css" href="/app/styles/user_profile_style.css" />

--- a/app/components/UserProfilePage.jsx
+++ b/app/components/UserProfilePage.jsx
@@ -45,12 +45,18 @@ class UserProfilePage extends Component {
     if (typeof this.props.id !== 'undefined') params = { userId: this.props.id };
     pageContent.fetchData('/profile', 'get', params)
       .then((responseJSON) => {
+        let link = responseJSON.linkedIn;
+
+        if (!link.startsWith('http://') && !link.startsWith('https://')) {
+          link = 'http://'.concat(link);
+        }
+
         this.setState({
           userType: responseJSON.type,
           name: responseJSON.name,
           imgURL: responseJSON.img_url,
           description: responseJSON.description,
-          linkedIn: responseJSON.linkedIn,
+          linkedIn: link,
           credentials: responseJSON.credentials,
           canModify: responseJSON.canModify,
           titles: [responseJSON.company],


### PR DESCRIPTION
The links in the profile page now have the http:// (or https://) in the beginning so the links should lead to the correct destination. Also, user creation now adds the scheme part automatically even if the admin didn't contain it in the address so in theory, the links should now always contain the scheme.